### PR TITLE
Cherry-pick: Add option to force TCP_QUICKACK.

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -63,6 +63,8 @@ import Network.Transport.TCP.Internal
   , tryShutdownSocketBoth
   , resolveSockAddr
   , EndPointId
+  , TCPInternalSettings(..)
+  , defaultTCPInternalSettings
   , encodeEndPointAddress
   , decodeEndPointAddress
   , randomEndPointAddress
@@ -512,6 +514,25 @@ data TCPParameters = TCPParameters {
     -- | Should we set TCP_NODELAY on connection sockets?
     -- Defaults to True.
   , tcpNoDelay :: Bool
+    -- | Should we enforce TCP_QUICKACK on connection sockets?
+    --
+    -- This setting is ignored on non-Linux systems, as they don't
+    -- have the TCP_QUICKACK socket option.
+    --
+    -- Enabling this on Linux < 2.4.4 will fail; the setting is NOT
+    -- ignored in that case, and you have to ensure that it's off
+    -- when using such an old Linux version.
+    --
+    -- Note that because TCP_QUICKACK is not a permanent socket option
+    -- (the kernel may reset it at any time), forcing it on or off
+    -- requires setting the socket option after every socket `recv`.
+    --
+    -- Setting it to `Nothing` does not set the socket option and
+    -- thus lets Linux do its heuristics; setting it to `Just True`
+    -- or `Just False` forces it on/off on supported platforms.
+    --
+    -- Defaults to Nothing.
+  , tcpForceQuickAck :: Maybe Bool
     -- | Value of TCP_USER_TIMEOUT in milliseconds
   , tcpKeepAlive :: Bool
     -- | Should we set TCP_KEEPALIVE on connection sockets?
@@ -667,6 +688,7 @@ defaultTCPParameters = TCPParameters {
   , tcpReuseServerAddr = True
   , tcpReuseClientAddr = True
   , tcpNoDelay         = False
+  , tcpForceQuickAck   = Nothing
   , tcpKeepAlive       = False
   , tcpUserTimeout     = Nothing
   , tcpNewQDisc        = simpleUnboundedQDisc
@@ -975,9 +997,9 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
     -- The peer must send our identifier and their address promptly, if a
     -- timeout is set.
     mAddrInfo <- maybe (fmap Just) System.Timeout.timeout connTimeout $ do
-      ourEndPointId <- recvWord32 sock
+      ourEndPointId <- recvWord32 settings sock
       let maxAddressLength = tcpMaxAddressLength $ transportParams transport
-      mTheirAddress <- BS.concat <$> recvWithLength maxAddressLength sock
+      mTheirAddress <- BS.concat <$> recvWithLength settings maxAddressLength sock
       -- Sending a length = 0 address means unaddressable.
       if BS.null mTheirAddress
       then fmap ((,) ourEndPointId . Left) randomEndPointAddress
@@ -1031,6 +1053,10 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
           throwIO $ userError "Transport closed"
       void $ go ourEndPoint theirAddress
   where
+    settings = defaultTCPInternalSettings
+      { tcpInternalForceQuickAck = tcpForceQuickAck $ transportParams transport
+      }
+
     go :: LocalEndPoint -> EndPointAddress -> IO ()
     go ourEndPoint theirAddress = do
       -- This runs in a thread that will never be killed
@@ -1129,6 +1155,10 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
       Left err -> prematureExit err
       Right sock -> tryIO (go sock) >>= either prematureExit return
   where
+    settings = defaultTCPInternalSettings
+      { tcpInternalForceQuickAck = tcpForceQuickAck params
+      }
+
     -- Dispatch
     --
     -- If a recv throws an exception this will be caught top-level and
@@ -1139,7 +1169,7 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
     -- exception thrown by 'recv'.
     go :: N.Socket -> IO ()
     go sock = do
-      lcid <- recvWord32 sock :: IO LightweightConnectionId
+      lcid <- recvWord32 settings sock :: IO LightweightConnectionId
       if lcid >= firstNonReservedLightweightConnectionId
         then do
           readMessage sock lcid
@@ -1147,13 +1177,13 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
         else
           case decodeControlHeader lcid of
             Just CreatedNewConnection -> do
-              recvWord32 sock >>= createdNewConnection
+              recvWord32 settings sock >>= createdNewConnection
               go sock
             Just CloseConnection -> do
-              recvWord32 sock >>= closeConnection
+              recvWord32 settings sock >>= closeConnection
               go sock
             Just CloseSocket -> do
-              didClose <- recvWord32 sock >>= closeSocket sock
+              didClose <- recvWord32 settings sock >>= closeSocket sock
               unless didClose $ go sock
             Just CloseEndPoint -> do
               let closeRemoteEndPoint vst = do
@@ -1345,7 +1375,7 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
     -- overhead
     readMessage :: N.Socket -> LightweightConnectionId -> IO ()
     readMessage sock lcid =
-      recvWithLength recvLimit sock >>=
+      recvWithLength settings recvLimit sock >>=
         qdiscEnqueue' ourQueue theirAddr . Received (connId lcid)
 
     -- Stop probing a connection as a result of receiving a probe ack.
@@ -1518,6 +1548,7 @@ setupRemoteEndPoint transport (ourEndPoint, theirEndPoint) connTimeout = do
                                theirAddress
                                (tcpReuseClientAddr params)
                                (tcpNoDelay params)
+                               (tcpForceQuickAck params)
                                (tcpKeepAlive params)
                                (tcpUserTimeout params)
                                connTimeout
@@ -1562,9 +1593,9 @@ setupRemoteEndPoint transport (ourEndPoint, theirEndPoint) connTimeout = do
         let handler :: SomeException -> IO (TransportError ConnectErrorCode)
             handler err = return (TransportError ConnectFailed (show err))
         err <- handle handler $ do
-          claimedHost <- recvWithLength (tcpMaxReceiveLength params) sock
-          actualNumericHost <- recvWithLength (tcpMaxReceiveLength params) sock
-          actualResolvedHost <- recvWithLength (tcpMaxReceiveLength params) sock
+          claimedHost <- recvWithLength settings (tcpMaxReceiveLength params) sock
+          actualNumericHost <- recvWithLength settings (tcpMaxReceiveLength params) sock
+          actualResolvedHost <- recvWithLength settings (tcpMaxReceiveLength params) sock
           let reason = concat [
                   "setupRemoteEndPoint: Host mismatch"
                 , ". Claimed: "
@@ -1594,6 +1625,10 @@ setupRemoteEndPoint transport (ourEndPoint, theirEndPoint) connTimeout = do
     ourAddress      = localAddress ourEndPoint
     theirAddress    = remoteAddress theirEndPoint
     invalidAddress  = TransportError ConnectNotFound
+
+    settings = defaultTCPInternalSettings
+      { tcpInternalForceQuickAck = tcpForceQuickAck params
+      }
 
 -- | Send a CloseSocket request if the remote endpoint is unused
 closeIfUnused :: EndPointPair -> IO ()
@@ -1977,12 +2012,13 @@ socketToEndPoint :: Maybe EndPointAddress -- ^ Our address
                  -> EndPointAddress       -- ^ Their address
                  -> Bool                  -- ^ Use SO_REUSEADDR?
                  -> Bool                  -- ^ Use TCP_NODELAY
+                 -> Maybe Bool            -- ^ Use TCP_QUICKACK
                  -> Bool                  -- ^ Use TCP_KEEPALIVE
                  -> Maybe Int             -- ^ Maybe TCP_USER_TIMEOUT
                  -> Maybe Int             -- ^ Timeout for connect
                  -> IO (Either (TransportError ConnectErrorCode)
                                (MVar (), N.Socket, ConnectionRequestResponse))
-socketToEndPoint mOurAddress theirAddress reuseAddr noDelay keepAlive
+socketToEndPoint mOurAddress theirAddress reuseAddr noDelay mForceQuickAck keepAlive
                  mUserTimeout timeout =
   try $ do
     (host, port, theirEndPointId) <- case decodeEndPointAddress theirAddress of
@@ -2009,7 +2045,7 @@ socketToEndPoint mOurAddress theirAddress reuseAddr noDelay keepAlive
                 (encodeWord32 theirEndPointId : prependLength [ourAddress])
             Nothing ->
               sendMany sock [encodeWord32 theirEndPointId, encodeWord32 0]
-          recvWord32 sock
+          recvWord32 settings sock
       case decodeConnectionRequestResponse response of
         Nothing -> throwIO (failed . userError $ "Unexpected response")
         Just r  -> do
@@ -2019,6 +2055,10 @@ socketToEndPoint mOurAddress theirAddress reuseAddr noDelay keepAlive
     createSocket :: N.AddrInfo -> IO N.Socket
     createSocket addr = mapIOException insufficientResources $
       N.socket (N.addrFamily addr) N.Stream N.defaultProtocol
+
+    settings = defaultTCPInternalSettings
+      { tcpInternalForceQuickAck = mForceQuickAck
+      }
 
     invalidAddress        = TransportError ConnectNotFound . show
     insufficientResources = TransportError ConnectInsufficientResources . show

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -15,6 +15,8 @@ module Network.Transport.TCP.Internal
   , tryShutdownSocketBoth
   , resolveSockAddr
   , EndPointId
+  , TCPInternalSettings(..)
+  , defaultTCPInternalSettings
   , encodeEndPointAddress
   , decodeEndPointAddress
   , randomEndPointAddress
@@ -43,7 +45,7 @@ import qualified Network.Socket as N
   , ServiceName
   , Socket
   , SocketType(Stream)
-  , SocketOption(ReuseAddr)
+  , SocketOption(ReuseAddr, CustomSockOpt)
   , getAddrInfo
   , defaultHints
   , socket
@@ -106,6 +108,21 @@ import qualified Data.UUID.V4 as UUID
 
 -- | Local identifier for an endpoint within this transport
 type EndPointId = Word32
+
+-- | Parameters that have to be passed to every socket function
+-- because they cannot be set on the socket permanently.
+data TCPInternalSettings = TCPInternalSettings {
+    -- | Whether to set TCP_QUICKACK after every `recv` and to what.
+    --
+    -- See the `tcpForceQuickAck` setting in "Network.Transport.TCP"
+    -- for which OSs this setting works on.
+    tcpInternalForceQuickAck :: Maybe Bool
+  }
+
+-- | Default internal TCP parameters.
+defaultTCPInternalSettings = TCPInternalSettings {
+    tcpInternalForceQuickAck = Nothing
+  }
 
 -- | Control headers
 data ControlHeader =
@@ -268,16 +285,16 @@ forkServer host port backlog reuseAddr errorHandler terminationHandler requestHa
 --   on the length.
 --   If the length (first 'Word32' received) is greater than the limit then
 --   an exception is thrown.
-recvWithLength :: Word32 -> N.Socket -> IO [ByteString]
-recvWithLength limit sock = do
-  len <- recvWord32 sock
+recvWithLength :: TCPInternalSettings -> Word32 -> N.Socket -> IO [ByteString]
+recvWithLength settings limit sock = do
+  len <- recvWord32 settings sock
   when (len > limit) $
     throwIO (userError "recvWithLength: limit exceeded")
-  recvExact sock len
+  recvExact settings sock len
 
 -- | Receive a 32-bit unsigned integer
-recvWord32 :: N.Socket -> IO Word32
-recvWord32 = fmap (decodeWord32 . BS.concat) . flip recvExact 4
+recvWord32 :: TCPInternalSettings -> N.Socket -> IO Word32
+recvWord32 settings = fmap (decodeWord32 . BS.concat) . flip (recvExact settings) 4
 
 -- | Close a socket, ignoring I/O exceptions.
 tryCloseSocket :: N.Socket -> IO ()
@@ -293,15 +310,30 @@ tryShutdownSocketBoth sock = void . tryIO $
 --
 -- Throws an I/O exception if the socket closes before the specified
 -- number of bytes could be read
-recvExact :: N.Socket        -- ^ Socket to read from
+recvExact :: TCPInternalSettings -- ^ Settings for specific TCP behaviour
+          -> N.Socket        -- ^ Socket to read from
           -> Word32          -- ^ Number of bytes to read
           -> IO [ByteString] -- ^ Data read
-recvExact sock len = go [] len
+recvExact settings sock len = go [] len
   where
     go :: [ByteString] -> Word32 -> IO [ByteString]
     go acc 0 = return (reverse acc)
     go acc l = do
       bs <- NBS.recv sock (fromIntegral l `min` smallChunkSize)
+      -- If forcing TCP_QUICKACK is enabled, set it after every recv()
+      -- (see also http://stackoverflow.com/questions/1615447/disable-tcp-delayed-acks).
+      -- Currently, this location is the only call to recv() in the package.
+      -- If other direct calls to `NBS.recv` are added anywhere, this
+      -- logic needs to be applied there as well!
+      case tcpInternalForceQuickAck settings of
+        Nothing -> return ()
+#ifdef linux_HOST_OS
+        Just forceVal -> do
+          let val = if forceVal then 1 else 0
+          N.setSocketOption sock (N.CustomSockOpt (6, 12)) val -- 6 is IPPROTO_TCP, 12 is TCP_QUICKACK
+#else
+        Just _forceVal -> return () -- Non-Linux OSs don't have TCP_QUICKACK.
+#endif
       if BS.null bs
         then throwIO (userError "recvExact: Socket closed")
         else go (bs : acc) (l - fromIntegral (BS.length bs))

--- a/src/Network/Transport/TCP/Mock/Socket.hs
+++ b/src/Network/Transport/TCP/Mock/Socket.hs
@@ -40,6 +40,7 @@ import Control.Exception (throwIO)
 import Control.Category ((>>>))
 import Control.Concurrent.MVar
 import Control.Concurrent.Chan
+import Foreign.C.Types (CInt)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Accessor (Accessor, accessor, (^=), (^.), (^:))
 import qualified Data.Accessor.Container as DAC (mapMaybe)
@@ -94,7 +95,7 @@ type PortNumber  = String
 type HostAddress = String
 
 data SocketType   = Stream
-data SocketOption = ReuseAddr
+data SocketOption = ReuseAddr | CustomSockOpt (CInt, CInt)
 data ShutdownCmd  = ShutdownSend
 
 data Family
@@ -185,6 +186,7 @@ defaultProtocol = error "defaultProtocol not implemented"
 
 setSocketOption :: Socket -> SocketOption -> Int -> IO ()
 setSocketOption _ ReuseAddr 1 = return ()
+setSocketOption _ CustomSockOpt{} _ = return ()
 setSocketOption _ _ _ = error "setSocketOption: unsupported arguments"
 
 accept :: Socket -> IO (Socket, SockAddr)

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -55,6 +55,8 @@ import Network.Transport.TCP.Internal
   , recvWord32
   , forkServer
   , recvWithLength
+  , TCPInternalSettings
+  , defaultTCPInternalSettings
   , encodeEndPointAddress
   , decodeEndPointAddress
   )
@@ -109,6 +111,10 @@ instance Traceable N.AddrInfo where
 
 instance Traceable TransportInternals where
   trace = const Nothing
+
+-- | Settings used for these tests
+settings :: TCPInternalSettings
+settings = defaultTCPInternalSettings
 
 -- Test that the server gets a ConnectionClosed message when the client closes
 -- the socket without sending an explicit control message to the server first
@@ -178,17 +184,17 @@ testEarlyDisconnect = do
       -- Listen for incoming messages
       (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
         -- Initial setup
-        0 <- recvWord32 sock
-        _ <- recvWithLength maxBound sock
+        0 <- recvWord32 settings sock
+        _ <- recvWithLength settings maxBound sock
         sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
         -- Server opens  a logical connection
-        Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
-        1024 <- recvWord32 sock :: IO LightweightConnectionId
+        Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 settings sock
+        1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
         -- Server sends a message
-        1024 <- recvWord32 sock
-        ["ping"] <- recvWithLength maxBound sock
+        1024 <- recvWord32 settings sock
+        ["ping"] <- recvWithLength settings maxBound sock
 
         -- Reply
         sendMany sock [
@@ -204,7 +210,7 @@ testEarlyDisconnect = do
       putMVar clientAddr ourAddress
 
       -- Connect to the server
-      Right (_, sock, ConnectionRequestAccepted) <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False False Nothing Nothing
+      Right (_, sock, ConnectionRequestAccepted) <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False Nothing False Nothing Nothing
 
       -- Open a new connection
       sendMany sock [
@@ -290,17 +296,17 @@ testEarlyCloseSocket = do
       -- Listen for incoming messages
       (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
         -- Initial setup
-        0 <- recvWord32 sock
-        _ <- recvWithLength maxBound sock
+        0 <- recvWord32 settings sock
+        _ <- recvWithLength settings maxBound sock
         sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
         -- Server opens a logical connection
-        Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
-        1024 <- recvWord32 sock :: IO LightweightConnectionId
+        Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 settings sock
+        1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
         -- Server sends a message
-        1024 <- recvWord32 sock
-        ["ping"] <- recvWithLength maxBound sock
+        1024 <- recvWord32 settings sock
+        ["ping"] <- recvWithLength settings maxBound sock
 
         -- Reply
         sendMany sock [
@@ -321,7 +327,7 @@ testEarlyCloseSocket = do
       putMVar clientAddr ourAddress
 
       -- Connect to the server
-      Right (_, sock, ConnectionRequestAccepted) <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False False Nothing Nothing
+      Right (_, sock, ConnectionRequestAccepted) <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False Nothing False Nothing Nothing
 
       -- Open a new connection
       sendMany sock [
@@ -415,20 +421,20 @@ testIgnoreCloseSocket = do
     theirAddress <- readMVar serverAddr
 
     -- Connect to the server
-    Right (_, sock, ConnectionRequestAccepted) <- socketToEndPoint (Just ourAddress) theirAddress True False False Nothing Nothing
+    Right (_, sock, ConnectionRequestAccepted) <- socketToEndPoint (Just ourAddress) theirAddress True False Nothing False Nothing Nothing
     putMVar connectionEstablished ()
 
     -- Server connects to us, and then closes the connection
-    Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
-    1024 <- recvWord32 sock :: IO LightweightConnectionId
+    Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 settings sock
+    1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
-    Just CloseConnection <- decodeControlHeader <$> recvWord32 sock
-    1024 <- recvWord32 sock :: IO LightweightConnectionId
+    Just CloseConnection <- decodeControlHeader <$> recvWord32 settings sock
+    1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
     -- Server will now send a CloseSocket request as its refcount reached 0
     tlog "Waiting for CloseSocket request"
-    Just CloseSocket <- decodeControlHeader <$> recvWord32 sock
-    _ <- recvWord32 sock :: IO LightweightConnectionId
+    Just CloseSocket <- decodeControlHeader <$> recvWord32 settings sock
+    _ <- recvWord32 settings sock :: IO LightweightConnectionId
 
     -- But we ignore it and request another connection in the other direction
     tlog "Ignoring it, requesting another connection"
@@ -501,20 +507,20 @@ testBlockAfterCloseSocket = do
     theirAddress <- readMVar serverAddr
 
     -- Connect to the server
-    Right (_, sock, ConnectionRequestAccepted) <- socketToEndPoint (Just ourAddress) theirAddress True False False Nothing Nothing
+    Right (_, sock, ConnectionRequestAccepted) <- socketToEndPoint (Just ourAddress) theirAddress True False Nothing False Nothing Nothing
     putMVar connectionEstablished ()
 
     -- Server connects to us, and then closes the connection
-    Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
-    1024 <- recvWord32 sock :: IO LightweightConnectionId
+    Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 settings sock
+    1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
-    Just CloseConnection <- decodeControlHeader <$> recvWord32 sock
-    1024 <- recvWord32 sock :: IO LightweightConnectionId
+    Just CloseConnection <- decodeControlHeader <$> recvWord32 settings sock
+    1024 <- recvWord32 settings sock :: IO LightweightConnectionId
 
     -- Server will now send a CloseSocket request as its refcount reached 0
     tlog "Waiting for CloseSocket request"
-    Just CloseSocket <- decodeControlHeader <$> recvWord32 sock
-    _ <- recvWord32 sock :: IO LightweightConnectionId
+    Just CloseSocket <- decodeControlHeader <$> recvWord32 settings sock
+    _ <- recvWord32 settings sock :: IO LightweightConnectionId
 
     unblocked <- newMVar False
 
@@ -522,7 +528,7 @@ testBlockAfterCloseSocket = do
     -- responding to the CloseSocket request (in this case, we
     -- respond by sending a ConnectionRequest)
     forkTry $ do
-      recvWord32 sock
+      recvWord32 settings sock
       readMVar unblocked >>= guard
       putMVar clientDone ()
 
@@ -567,7 +573,7 @@ testUnnecessaryConnect numThreads = do
       forkTry $ do
         -- It is possible that the remote endpoint just rejects the request by closing the socket
         -- immediately (depending on far the remote endpoint got with the initialization)
-        response <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False False Nothing Nothing
+        response <- readMVar serverAddr >>= \addr -> socketToEndPoint (Just ourAddress) addr True False Nothing False Nothing Nothing
         case response of
           Right (_, _, ConnectionRequestAccepted) ->
             -- We don't close this socket because we want to keep this connection open
@@ -649,8 +655,8 @@ testReconnect = do
   -- Server
   (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
     -- Accept the connection
-    Right 0  <- tryIO $ recvWord32 sock
-    Right _  <- tryIO $ recvWithLength maxBound sock
+    Right 0  <- tryIO $ recvWord32 settings sock
+    Right _  <- tryIO $ recvWithLength settings maxBound sock
 
     -- The first time we close the socket before accepting the logical connection
     count <- modifyMVar counter $ \i -> return (i + 1, i)
@@ -672,15 +678,15 @@ testReconnect = do
         -- On the third and fourth requests, a new logical connection is
         -- accepted.
         -- On the third request the socket then closes.
-        Right (Just CreatedNewConnection) <- tryIO $ decodeControlHeader <$> recvWord32 sock
-        connId <- recvWord32 sock :: IO LightweightConnectionId
+        Right (Just CreatedNewConnection) <- tryIO $ decodeControlHeader <$> recvWord32 settings sock
+        connId <- recvWord32 settings sock :: IO LightweightConnectionId
 
         when (count > 2) $ do
           -- On the fourth request, a message is received and then the socket
           -- is closed.
-          Right connId' <- tryIO $ (recvWord32 sock :: IO LightweightConnectionId)
+          Right connId' <- tryIO $ (recvWord32 settings sock :: IO LightweightConnectionId)
           True <- return $ connId == connId'
-          Right ["ping"] <- tryIO $ recvWithLength maxBound sock
+          Right ["ping"] <- tryIO $ recvWithLength settings maxBound sock
           putMVar serverDone ()
 
     return ()
@@ -775,16 +781,16 @@ testUnidirectionalError = do
     -- fail, but we don't want to close that socket at that point (which
     -- would shutdown the socket in the other direction)
     void . (try :: IO () -> IO (Either SomeException ())) $ do
-      0 <- recvWord32 sock
-      _ <- recvWithLength maxBound sock
+      0 <- recvWord32 settings sock
+      _ <- recvWithLength settings maxBound sock
       () <- sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
-      Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
-      connId <- recvWord32 sock :: IO LightweightConnectionId
+      Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 settings sock
+      connId <- recvWord32 settings sock :: IO LightweightConnectionId
 
-      connId' <- recvWord32 sock :: IO LightweightConnectionId
+      connId' <- recvWord32 settings sock :: IO LightweightConnectionId
       True <- return $ connId == connId'
-      ["ping"] <- recvWithLength maxBound sock
+      ["ping"] <- recvWithLength settings maxBound sock
       putMVar serverGotPing ()
 
     -- Must read the clientDone MVar so that we don't close the socket


### PR DESCRIPTION
It is well known that Nagle's algorithm (the absence of TCP_NODELAY)
and delayed acknowledgements (the absence of TCP_QUICKACK) cause
performance issues on TCP; see for example:

* https://eklitzke.org/the-caveats-of-tcp-nodelay
* http://jvns.ca/blog/2015/11/21/why-you-should-understand-a-little-about-tcp/

TCP_NODELAY was already implemented; this commit adds TCP_QUICKACK.

This change breaks the external API, because `socketToEndPoint`
(for reasons not obvious to me) takes all socket options as individual
arguments, instead of as a settings object.